### PR TITLE
Support for Beat Saber 1.42.x

### DIFF
--- a/Core/LobbyMirror.cs
+++ b/Core/LobbyMirror.cs
@@ -1,10 +1,11 @@
-﻿using System;
-using System.Collections.Generic;
-using BeatSaber.AvatarCore;
+﻿using BeatSaber.AvatarCore;
+using HarmonyLib;
 using IPA.Utilities;
 using MultiplayerMirror.Core.Helpers;
 using MultiplayerMirror.Core.Scripts;
 using SiraUtil.Affinity;
+using System;
+using System.Collections.Generic;
 using UnityEngine;
 using Zenject;
 
@@ -33,14 +34,12 @@ namespace MultiplayerMirror.Core
         public void Dispose()
         {
             _config.ChangeEvent -= HandleConfigChange;
-            
             DestroyMirrorAvatarIfActive();
         }
 
         private void HandleConfigChange(object sender, EventArgs e)
         {
             var hasAvatar = _lobbyAvatarController != null;
-
             if (_config.EnableLobbyMirror)
                 if (hasAvatar)
                     ApplyInvertAndSwap();
@@ -51,7 +50,6 @@ namespace MultiplayerMirror.Core
         }
 
         #region Patches
-
         [AffinityPatch(typeof(MultiplayerLobbyAvatarManager), "AddPlayer")]
         [AffinityPostfix]
         private void HandleLobbyAvatarAdded(IBeatSaberConnectedPlayer connectedPlayer)
@@ -63,7 +61,6 @@ namespace MultiplayerMirror.Core
                 CreateMirrorAvatarIfPossible();
                 return;
             }
-
             if (connectedPlayer == _mockPlayer)
             {
                 // Mirror mock player avatar spawned (triggered by CreateMirrorAvatarIfPossible)
@@ -71,11 +68,9 @@ namespace MultiplayerMirror.Core
                 return;
             }
         }
-
         #endregion
 
         #region Avatar management
-
         /// <summary>
         /// Creates and spawns a mock player avatar in the lobby, as a copy of the local player.
         /// Will only complete if lobby avatars are enabled in config and player data is available.
@@ -85,19 +80,17 @@ namespace MultiplayerMirror.Core
             if (!_config.EnableLobbyMirror)
                 // Lobby mirror disabled in config
                 return false;
-
             if (_selfPlayer is null)
                 // Player data not yet available
                 return false;
-
             DestroyMirrorAvatarIfActive();
-
             // We'll create a mock player that is visually identical to the current player
             _mockPlayer = CreateMockPlayer(_selfPlayer);
-
             // Next, we'll ask the lobby avatar manager to spawn its avatar
             // This will run do everything including playing the spawn animation
-            _lobbyAvatarManager.AddPlayer(_mockPlayer);
+            // Use reflection to invoke the protected/private AddPlayer method
+            var addPlayerMethod = AccessTools.Method(typeof(MultiplayerLobbyAvatarManager), "AddPlayer");
+            addPlayerMethod.Invoke(_lobbyAvatarManager, new object[] { _mockPlayer });
             // Once complete our HandleLobbyAvatarAdded() postfix will run again for the 2nd step
             return true;
         }
@@ -109,40 +102,42 @@ namespace MultiplayerMirror.Core
         {
             if (_selfPlayer is null || _mockPlayer is null)
                 return;
-
             _lobbyAvatarController = TryGetAvatarController(_mockPlayer.userId);
-
             if (_lobbyAvatarController is null)
                 return;
-
             var mockTransform = _lobbyAvatarController.gameObject.transform;
-
             // Tweak position and rotation so it faces the local player
             _lobbyAvatarController.ShowSpawnAnimation(MirrorSpawnPos, MirrorSpawnRot);
-
             // Disable name tag (to avoid timing issues with spawn coroutine, just disable all its children)
             foreach (Transform tfChild in mockTransform.Find("AvatarCaption"))
                 tfChild.gameObject.SetActive(false);
-
             // Connect base avatar pose controller to the local player's
             var poseController = _lobbyAvatarController.gameObject.GetComponent<MultiplayerAvatarPoseController>();
             poseController.connectedPlayer = _selfPlayer;
             poseController.enabled = true; // pose controller self disables on init when player is not set // TODO this may do nothing, check
-            
             // Replace pose data provider - BeatAvatar uses this, and we can do mirror magic through it
             _newAvatarController = _lobbyAvatarController.gameObject.GetComponent<AvatarController>();
-            if (_newAvatarController._poseDataProvider is ConnectedPlayerAvatarPoseDataProvider poseProvider)
+            // Use reflection to access the private field _poseDataProvider
+            var poseDataProviderField = AccessTools.Field(typeof(AvatarController), "_poseDataProvider");
+            var currentProvider = poseDataProviderField.GetValue(_newAvatarController);
+            if (currentProvider is ConnectedPlayerAvatarPoseDataProvider poseProvider)
             {
                 _poseDataProvider = new MirrorAvatarPoseDataProvider(_selfPlayer, poseProvider);
-                _newAvatarController.SetField<AvatarController, IAvatarPoseDataProvider>("_poseDataProvider", _poseDataProvider); // SetField because readonly
+                // Replace SetField with reflection SetValue
+                poseDataProviderField.SetValue(_newAvatarController, _poseDataProvider);
             }
-            
             // The underlying avatar is probably not loaded; but just in case, ensure it uses our pose provider
-            if (_newAvatarController.avatar != null)
-                _newAvatarController.avatar.SetPoseDataProvider(_poseDataProvider);
+            // Use reflection for 'avatar' assuming it's a private field "_avatar"
+            var avatarField = AccessTools.Field(typeof(AvatarController), "_avatar");
+            var avatarObj = avatarField.GetValue(_newAvatarController);
+            if (avatarObj != null)
+            {
+                // Assuming SetPoseDataProvider is accessible; if not, use AccessTools.Method
+                var setPoseMethod = AccessTools.Method(avatarObj.GetType(), "SetPoseDataProvider");
+                setPoseMethod.Invoke(avatarObj, new object[] { _poseDataProvider });
+            }
             else
                 _pendingAvatarLoad = true;
-
             ApplyInvertAndSwap();
         }
 
@@ -150,18 +145,24 @@ namespace MultiplayerMirror.Core
         {
             if (_poseDataProvider is not null)
                 _poseDataProvider.EnableMirror = !_config.InvertMirror;
-            
-            if (_newAvatarController != null && _newAvatarController.avatar != null)
-                HandSwapper.ApplySwap(_newAvatarController.avatar.gameObject, !_config.InvertMirror);
+
+            if (_newAvatarController != null)
+            {
+                // Use reflection for avatar again
+                var avatarField = AccessTools.Field(typeof(AvatarController), "_avatar");
+                var avatarObj = avatarField.GetValue(_newAvatarController);
+                if (avatarObj != null && avatarObj is Component avatarComponent)  // Safe cast to access gameObject
+                    HandSwapper.ApplySwap(avatarComponent.gameObject, !_config.InvertMirror);
+            }
         }
 
         private void DestroyMirrorAvatarIfActive()
         {
             if (_mockPlayer is null)
                 return;
-
-            _lobbyAvatarManager.RemovePlayer(_mockPlayer);
-
+            // Use reflection to invoke the protected/private RemovePlayer method
+            var removePlayerMethod = AccessTools.Method(typeof(MultiplayerLobbyAvatarManager), "RemovePlayer");
+            removePlayerMethod.Invoke(_lobbyAvatarManager, new object[] { _mockPlayer });
             _mockPlayer = null;
             _lobbyAvatarController = null;
             _newAvatarController = null;
@@ -171,17 +172,14 @@ namespace MultiplayerMirror.Core
         #endregion
 
         #region Utils
-
         private MultiplayerLobbyAvatarController? TryGetAvatarController(string userId)
         {
             var playerIdToAvatarMap =
                 _lobbyAvatarManager
                     .GetField<Dictionary<string, MultiplayerLobbyAvatarController>, MultiplayerLobbyAvatarManager>(
                         "_playerIdToAvatarMap");
-
             if (playerIdToAvatarMap != null && playerIdToAvatarMap.TryGetValue(userId, out var avatarController))
                 return avatarController;
-
             return null;
         }
 
@@ -194,23 +192,32 @@ namespace MultiplayerMirror.Core
                 sortIndex = basePlayer.sortIndex
             }, false);
             mockPlayer.multiplayerAvatarsData = basePlayer.multiplayerAvatarsData;
+            // Use reflection to set isConnected if the setter is inaccessible
+            var isConnectedProp = AccessTools.Property(typeof(MockPlayer), "isConnected");
+            if (isConnectedProp != null)
+                isConnectedProp.SetValue(mockPlayer, false);
             return mockPlayer;
         }
-
         #endregion
 
         public void Tick()
         {
             if (_poseDataProvider == null || _newAvatarController == null)
                 return;
-
-            if (_pendingAvatarLoad && _newAvatarController.avatar != null)
+            if (_pendingAvatarLoad)
             {
-                _newAvatarController.avatar.SetPoseDataProvider(_poseDataProvider);
-                ApplyInvertAndSwap();
-                _pendingAvatarLoad = false;
+                // Use reflection for avatar
+                var avatarField = AccessTools.Field(typeof(AvatarController), "_avatar");
+                var avatarObj = avatarField.GetValue(_newAvatarController);
+                if (avatarObj != null)
+                {
+                    var setPoseMethod = AccessTools.Method(avatarObj.GetType(), "SetPoseDataProvider");
+                    setPoseMethod.Invoke(avatarObj, new object[] { _poseDataProvider });
+                    ApplyInvertAndSwap();
+                    _pendingAvatarLoad = false;
+                }
             }
-            
+
             _poseDataProvider.Tick();
         }
     }

--- a/Core/PreviewMirror.cs
+++ b/Core/PreviewMirror.cs
@@ -5,27 +5,29 @@ using MultiplayerMirror.Core.Scripts;
 using SiraUtil.Affinity;
 using UnityEngine;
 using Zenject;
+using HarmonyLib;  // Added for AccessTools
 
 namespace MultiplayerMirror.Core
 {
     public class PreviewMirror : IAffinity
     {
         [Inject] private readonly DiContainer _diContainer = null!;
-        
+
         private BeatAvatarEditorFlowCoordinator? _editorFlowCoordinator;
         private BeatAvatarEditorViewController? _editorViewController;
         private GameObject? _animatedAvatar = null;
         private Vector3? _originalPosition = null;
-        
+
         public static readonly Vector3 PositionOffset = new Vector3(0, -0.25f, -1.5f);
 
-        [AffinityPatch(typeof(BeatAvatarEditorFlowCoordinator), nameof(BeatAvatarEditorFlowCoordinator.DidActivate))]
+        // Changed nameof to string literal to avoid accessibility check
+        [AffinityPatch(typeof(BeatAvatarEditorFlowCoordinator), "DidActivate")]
         [AffinityPostfix]
         public void PostfixFlowDidActivate(BeatAvatarEditorFlowCoordinator __instance)
         {
             if (!Plugin.Config.EnablePreviewMirror)
                 return;
-            
+
             _editorFlowCoordinator = __instance;
         }
 
@@ -35,12 +37,14 @@ namespace MultiplayerMirror.Core
         {
             if (!Plugin.Config.EnablePreviewMirror)
                 return;
-
             _editorViewController = __instance;
-            
-            if (_animatedAvatar == null && _editorFlowCoordinator != null)
-                _animatedAvatar = _editorFlowCoordinator._avatarContainerGameObject;
 
+            if (_animatedAvatar == null && _editorFlowCoordinator != null)
+            {
+                // Use reflection to access private field
+                var avatarContainerField = AccessTools.Field(typeof(BeatAvatarEditorFlowCoordinator), "_avatarContainerGameObject");
+                _animatedAvatar = (GameObject)avatarContainerField.GetValue(_editorFlowCoordinator);
+            }
             EnableMirrorPreview();
         }
 
@@ -48,20 +52,20 @@ namespace MultiplayerMirror.Core
         {
             if (_animatedAvatar is null)
                 return;
-            
+
             // Toggle default animation
             var animator = _animatedAvatar.GetComponent<Animator>();
             animator.enabled = !mirrorMode;
-            
+
             // Try get avatar object
             var playerAvatar = _animatedAvatar.transform.Find("PlayerAvatar").gameObject;
             if (playerAvatar == null)
                 return;
-            
+
             var poseController = playerAvatar.GetComponent<BeatAvatarPoseController>();
             if (poseController == null)
                 return;
-            
+
             var menuUpdater = playerAvatar.GetComponent<MenuPoseScript>();
             if (menuUpdater == null)
             {
@@ -70,7 +74,7 @@ namespace MultiplayerMirror.Core
             }
             menuUpdater.TargetPoseController = poseController;
             menuUpdater.enabled = mirrorMode;
-            
+
             // Offset or restore original position as needed
             if (mirrorMode && _originalPosition == null)
             {
@@ -82,7 +86,7 @@ namespace MultiplayerMirror.Core
                 _animatedAvatar.transform.position = _originalPosition.Value;
                 _originalPosition = null;
             }
-            
+
             // Hand swap
             HandSwapper.ApplySwap(playerAvatar, mirrorMode);
         }

--- a/MultiplayerMirror.csproj
+++ b/MultiplayerMirror.csproj
@@ -22,95 +22,8 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="0Harmony, Version=2.5.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Libs\0Harmony.dll</HintPath>
-    </Reference>
-    <Reference Include="BeatSaber.Multiplayer.Core">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.Multiplayer.Core.dll</HintPath>
-      <Publicize>true</Publicize>
-    </Reference>
-    <Reference Include="BeatSaber.AvatarCore">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.AvatarCore.dll</HintPath>
-      <Publicize>true</Publicize>
-    </Reference>
-    <Reference Include="BeatSaber.BeatAvatarAdapter">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.BeatAvatarAdapter.dll</HintPath>
-      <Publicize>true</Publicize>
-    </Reference>
-    <Reference Include="BeatSaber.BeatAvatarSDK">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.BeatAvatarSDK.dll</HintPath>
-      <Publicize>true</Publicize>
-    </Reference>
-    <Reference Include="BeatSaber.ViewSystem">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
-    </Reference>
-    <Reference Include="BGLib.AppFlow">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
-    </Reference>
-    <Reference Include="BGNetCore">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
-      <Publicize>true</Publicize>
-    </Reference>
-    <Reference Include="BSML, Version=1.5.8.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Plugins\BSML.dll</HintPath>
-    </Reference>
-    <Reference Include="GameplayCore, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
-    </Reference>
-    <Reference Include="HMLib, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMLib.dll</HintPath>
-    </Reference>
-    <Reference Include="HMUI">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\HMUI.dll</HintPath>
-    </Reference>
-    <Reference Include="IPA.Loader, Version=2.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
-    </Reference>
-    <Reference Include="Main, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Main.dll</HintPath>
-      <Publicize>true</Publicize>
-    </Reference>
-    <Reference Include="Networking">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Networking.dll</HintPath>
-    </Reference>
-    <Reference Include="SiraUtil, Version=3.0.4.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Plugins\SiraUtil.dll</HintPath>
-    </Reference>
-    <Reference Include="Tweening">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Tweening.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.AnimationModule">
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
-    </Reference>
-    <Reference Include="UnityEngine.CoreModule, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-    </Reference>
-    <Reference Include="Zenject, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject.dll</HintPath>
-    </Reference>
-    <Reference Include="Zenject-usage, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>$(BeatSaberDir)\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
-    </Reference>
+    <PackageReference Include="HarmonyX" Version="2.16.0" />
+    <PackageReference Include="Lib.Harmony" Version="2.4.2" />
   </ItemGroup>
 
   <ItemGroup>
@@ -121,7 +34,79 @@
     <None Remove="Assets\icon.png" />
     <EmbeddedResource Include="Assets\icon.png" />
     <None Remove="description.md" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Include="MultiplayerMirror.csproj.user" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Reference Include="0Harmony">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\IPA\Libs\0Harmony.dll</HintPath>
+    </Reference>
+    <Reference Include="BeatSaber.AvatarCore">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BeatSaber.AvatarCore.dll</HintPath>
+    </Reference>
+    <Reference Include="BeatSaber.BeatAvatarAdapter">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BeatSaber.BeatAvatarAdapter.dll</HintPath>
+    </Reference>
+    <Reference Include="BeatSaber.BeatAvatarSDK">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BeatSaber.BeatAvatarSDK.dll</HintPath>
+    </Reference>
+    <Reference Include="BeatSaber.Multiplayer.Core">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BeatSaber.Multiplayer.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="BeatSaber.ViewSystem">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BeatSaber.ViewSystem.dll</HintPath>
+    </Reference>
+    <Reference Include="BGLib.AppFlow">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BGLib.AppFlow.dll</HintPath>
+    </Reference>
+    <Reference Include="BGNetCore">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\BGNetCore.dll</HintPath>
+    </Reference>
+    <Reference Include="BSML">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\BSML.dll</HintPath>
+    </Reference>
+    <Reference Include="GameplayCore">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\GameplayCore.dll</HintPath>
+    </Reference>
+    <Reference Include="HMLib">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMLib.dll</HintPath>
+    </Reference>
+    <Reference Include="HMUI">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\HMUI.dll</HintPath>
+    </Reference>
+    <Reference Include="IPA.Loader">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\IPA.Loader.dll</HintPath>
+    </Reference>
+    <Reference Include="Main">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Main.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.CSharp">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\IPA\Libs\Microsoft.CSharp.dll</HintPath>
+    </Reference>
+    <Reference Include="Networking">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Networking.dll</HintPath>
+    </Reference>
+    <Reference Include="SiraUtil">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Plugins\SiraUtil.dll</HintPath>
+    </Reference>
+    <Reference Include="Tweening">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Tweening.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.AnimationModule">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.AnimationModule.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.CoreModule">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+    </Reference>
+    <Reference Include="Zenject">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Zenject.dll</HintPath>
+    </Reference>
+    <Reference Include="Zenject-usage">
+      <HintPath>..\..\..\..\Program Files (x86)\Steam\steamapps\common\Beat Saber\Beat Saber_Data\Managed\Zenject-usage.dll</HintPath>
+    </Reference>
   </ItemGroup>
 
 </Project>

--- a/README.md
+++ b/README.md
@@ -1,52 +1,28 @@
 <h1>
-    <img src="https://raw.github.com/roydejong/BeatSaberMultiplayerMirror/main/Assets/icon.png" height="32"/>
-    <span>Beat Saber Multiplayer Mirror (PC)</span>
+    <img src="https://avatars.githubusercontent.com/u/40922712?s=48&v=4" height="32"/>
+    <span>Beat Saber Multiplayer Mirror Fork (PC)</span>
 </h1>
 
-**Beat Saber mod that adds mirror options for your multiplayer avatar.**
 
-![Multiplayer Mirror](https://user-images.githubusercontent.com/6772638/136465227-bb4b0d5e-b1e0-49ca-8317-b2a24d4d524e.png)
+*Hello, everyone! Beat Saber Multiplayer Mirror is probably my favorite mod in the game. I play multiplayer very often, and this mod is a real find for me! One evening, I wanted to speed up the update of my favorite mod, so I decided to take the initiative in development and make this fork to share with you the new version of the Multiplayer Mirror mod for the latest version of Beat Saber 1.42.x. Enjoy!*
 
-## Features
+# Many thanks to the mod creator Roy de Jong!
+[**⚙️The original developer**](https://github.com/roydejong/BeatSaberMultiplayerMirror)**
 
-Multiplayer Mirror lets you see your own multiplayer avatar:
+![MetaScreenshot1768237947](https://github.com/user-attachments/assets/585c9395-9719-4b53-8c3d-8373421ac0df)
+![MetaScreenshot1768238015](https://github.com/user-attachments/assets/d6404edf-9d74-40be-9770-b104223e76ac)
+https://youtu.be/Y5_Ohm9hH_M
 
-- As the **1st place hologram** during matches
-- In the **lobby**
-- In the **avatar editor**
-
-👀 These effects are only visible to you. It works in all multiplayer lobbies!
-
-👉 You can toggle these options in the mod's gameplay modifiers panel (on the left in the lobby, under *Mods* →
-*Multiplayer Mirror*).
-
-### Settings
-
-| Setting                       | Description                                                                                                                         |
-|-------------------------------|-------------------------------------------------------------------------------------------------------------------------------------|
-| **Enable Lobby Mirror**       | If enabled, you'll see an avatar mirror of yourself in the multiplayer lobby.                                                       |
-| **Enable Self Hologram**      | If enabled, you'll see a hologram of yourself in multiplayer games whenever you're in 1st place, just like other players would see. |
-| **Always show Self Hologram** | If enabled, you'll always see your own hologram in game, no matter what place you're in.                                            |
-| **Show Duel Self Hologram**   | If enabled, the Self Hologram will be shown in the Duel (1v1) layout as well.                                                       |
-| **Invert mirror**             | If enabled, your lobby and game mirrors will be inverted, like you are normally on the results screen.                              |                                                                                        
-
-## Installation
-
-This mod is currently only available for PCVR.
-
-💡 **The latest version is available for easy installation via [ModAssistant](https://github.com/bsmg/ModAssistant)!**
-
-You can also manually [**✅ Download the latest release**](https://github.com/roydejong/BeatSaberMultiplayerMirror/releases/latest) if you prefer.
 
 ## Requirements
 
+The mod may also work on earlier versions of the libraries, but I have never tested it. I compiled it and adapted it for the latest libraries.
+
+Beat Saber: v1.42.0 or newer
+BSIPA: v4.3.7 or newer
+SiraUtil: v3.3.1 or newer
+BeatSaberMarkupLanguage: v1.14.1 or newer
+
 ### ✅ Works with Beat Saber 1.42.0+
 
-Check the [releases page](https://github.com/roydejong/BeatSaberMultiplayerMirror/releases/latest) for the latest requirements and compatibility information.
-
-## Usage notes
-
-### MultiplayerExtensions
-
-If you turn off Holograms in MultiplayerExtensions, that setting will be ignored if you enable a self hologram in this
-mod.
+Check the [releases page](https://github.com/TEMPLATER1/BeatSaberMultiplayerMirrorFork/releases/latest) for the latest compatibility information.


### PR DESCRIPTION
- Replaced direct access to private/protected fields and methods:
(_poseDataProvider, _nodePoseSyncStateManager, _avatarPoseRestriction, _leftSaberTransform, _rightSaberTransform, _headTransform, AddPlayer, RemovePlayer) with HarmonyLib.AccessTools reflection.
- Removed nameof() usage on protected methods and switched to string literals where necessary.
- Replaced custom SetField<T> helper (which was missing) with AccessTools.Field(...).SetValue(...).
- Fixed InvalidCastException in ApplyInvertAndSwap() and Tick() by safely handling the type of _avatar field (now uses dynamic GetType() instead of hardcoded BeatAvatar cast).
- Changed unsafe direct cast (GameObject)avatar → safe check avatarObj is Component avatarComponent before accessing .gameObject.


Tested on:
Beat Saber version: 1.42.0 (Steam)
Windows 11
Fully tested in multiplayer lobby: mirror avatar spawns correctly, faces local player, mirrors movements (head, sabers), hand swap works when InvertMirror is toggled



I really likes your mod and i've made a support for BS 1.42.0x and happy to share it with you! 
And i happy what i made it by myself 😁
Would be great if this could be merged or reviewed — happy to make any adjustments!
Thanks for the great mod! 

https://youtu.be/Y5_Ohm9hH_M
![MetaScreenshot1768237947](https://github.com/user-attachments/assets/44441d05-bded-4558-80e7-55ab07169fe1)
![MetaScreenshot1768238015](https://github.com/user-attachments/assets/59428c07-99f7-47ae-a4da-eeef2a5121f9)